### PR TITLE
add process-next to level.dtsi

### DIFF
--- a/boards/shields/levels/levels.dtsi
+++ b/boards/shields/levels/levels.dtsi
@@ -114,6 +114,7 @@
     scroll {
       layers = <6>;
       input-processors = <&zip_xy_scaler 1 12>;
+      process-next;
     };
   };
 


### PR DESCRIPTION
This passes the rest of the processors through when on layer 6, fixing an issue where the x and y swap isn't inherited